### PR TITLE
Add HTTP resolution via .well-known DID endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,12 +253,37 @@
 
       <section>
         <h3>Read (Resolve)</h3>
-        <p>
-          Resolving a did:nostr identifier involves the following steps:
-        </p>
+        
+        <p>DID resolution for <code>did:nostr</code> identifiers follows this strategy:</p>
+        
         <ol>
-          <li>Parse the identifier to extract the 64-character hexadecimal public key</li>
-          <li>Construct a DID Document with the following properties:
+          <li><strong>HTTP Resolution</strong> - Check <code>https://&lt;domain&gt;/.well-known/did/nostr/&lt;pubkey&gt;.json</code></li>
+          <li><strong>Offline-first Resolution</strong> - Generate minimal DID document from public key alone</li>
+          <li><strong>Enhanced Resolution</strong> - Optionally query Nostr relays for additional metadata</li>
+        </ol>
+        
+        <section>
+          <h4>HTTP Resolution</h4>
+          <p>
+            Servers can host complete DID documents at:
+          </p>
+          <pre><code>https://example.com/.well-known/did/nostr/&lt;pubkey&gt;.json</code></pre>
+          <p>
+            Where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hex public key. The endpoint SHOULD return a complete DID document (minimal or enhanced).
+          </p>
+          <p>
+            This enables fast, cacheable resolution without requiring cryptographic computation or relay queries. Servers can serve minimal documents for offline-first scenarios or enhanced documents with service endpoints and metadata.
+          </p>
+        </section>
+        
+        <section>
+          <h4>Offline-first Resolution</h4>
+          <p>
+            Resolving a did:nostr identifier offline involves the following steps:
+          </p>
+          <ol>
+            <li>Parse the identifier to extract the 64-character hexadecimal public key</li>
+            <li>Construct a DID Document with the following properties:
             <ul>
               <li>Set the <code>id</code> field to the full DID</li>
               <li>Include a Multikey verification method, transforming the x-only public key following the multicodec/multibase encoding process</li>


### PR DESCRIPTION
## Summary
Documents HTTP resolution as the primary resolution strategy via `.well-known/did/nostr/<pubkey>.json` endpoints that serve complete DID documents.

## Key Changes
- **HTTP Resolution First**: Check `.well-known/did/nostr/<pubkey>.json` for complete DID documents  
- **Server Flexibility**: Servers can return minimal or enhanced DID documents as appropriate
- **Caching Benefits**: Enables standard HTTP caching, CDN distribution, and web performance optimization
- **Offline Fallback**: Maintains offline-first resolution as reliable fallback

## Endpoint Format
```
https://example.com/.well-known/did/nostr/<pubkey>.json
```

Returns a complete DID document (not just metadata).

## Benefits
- **Performance**: Direct HTTP requests, no computation required
- **Caching**: Standard web caching mechanisms apply  
- **Scalability**: CDN distribution, server-side optimization
- **Flexibility**: Servers choose minimal vs enhanced documents
- **Reliability**: Falls back to offline-first if HTTP unavailable

## Implementation Impact
This makes DID resolution web-native while preserving Nostr's offline-first philosophy. Servers can pre-compute and cache DID documents for optimal performance.

## Use Cases
- **Static Hosting**: GitHub Pages, Netlify can serve pre-computed DID documents
- **CDN Distribution**: Global caching for fast resolution worldwide  
- **Server Optimization**: Pre-compute documents with enhanced metadata
- **Web Integration**: Standard HTTP patterns familiar to web developers

## Addresses
Closes #43