### PR TITLE
Add HTTP resolution via .well-known DID endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,6 +280,28 @@
       <section>
         <h3>Read (Resolve)</h3>
         
+        <p>DID resolution for <code>did:nostr</code> identifiers follows this strategy:</p>
+        
+        <ol>
+          <li><strong>HTTP Resolution</strong> - Check <code>https://&lt;domain&gt;/.well-known/did/nostr/&lt;pubkey&gt;.json</code></li>
+          <li><strong>Offline-first Resolution</strong> - Generate minimal DID document from public key alone</li>
+          <li><strong>Enhanced Resolution</strong> - Optionally query Nostr relays for additional metadata</li>
+        </ol>
+        
+        <section>
+          <h4>HTTP Resolution</h4>
+          <p>
+            Servers can host complete DID documents at:
+          </p>
+          <pre><code>https://example.com/.well-known/did/nostr/&lt;pubkey&gt;.json</code></pre>
+          <p>
+            Where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hex public key. The endpoint SHOULD return a complete DID document (minimal or enhanced).
+          </p>
+          <p>
+            This enables fast, cacheable resolution without requiring cryptographic computation or relay queries. Servers can serve minimal documents for offline-first scenarios or enhanced documents with service endpoints and metadata.
+          </p>
+        </section>
+        
         <section>
           <h4>Minimal Resolution</h4>
           <p>


### PR DESCRIPTION
Adds HTTP resolution as primary strategy via .well-known/did/nostr/<pubkey>.json endpoints that serve complete DID documents. Enables fast, cacheable resolution while maintaining offline-first fallback. Addresses #43.