### PR TITLE
Fix ReSpec versioning configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
+        subtitle: 'Version 0.0.1',
+        latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {
             name: 'Melvin Carvalho',
@@ -56,49 +58,6 @@
         This document is a work in progress and may be updated, replaced, or obsoleted by other documents at any time.
         It is inappropriate to cite this document as other than work in progress.
       </p>
-    </section>
-    
-    <section>
-      <h2>Version</h2>
-      <p>
-        This document specifies <strong>DID-Nostr version 0.0.1</strong> (Experimental).
-      </p>
-      
-      <section>
-        <h3>Stability Notice</h3>
-        <p>
-          This specification is under active development. While the core functionality 
-          is working and usable, implementers should expect changes. Breaking changes 
-          may occur in minor version updates (0.x.0) until version 1.0.0.
-        </p>
-      </section>
-      
-      <section>
-        <h3>Version History</h3>
-        <ul>
-          <li><strong>0.0.1</strong> (2025-01-27) - Initial experimental release:
-            <ul>
-              <li>Basic DID operations (create, resolve)</li>
-              <li>Multikey verification method</li>
-              <li>HTTP resolution via .well-known endpoints</li>
-              <li>Profile field support (experimental)</li>
-              <li>Nostr-Timestamp header for caching</li>
-            </ul>
-          </li>
-        </ul>
-      </section>
-      
-      <section>
-        <h3>Roadmap to 1.0.0</h3>
-        <p>Features and improvements planned before stable release:</p>
-        <ul>
-          <li>Enhanced relay consensus strategies</li>
-          <li>Event type mappings (kind 0, 3, 10002)</li>
-          <li>Test vectors and reference implementations</li>
-          <li>Error handling specifications</li>
-          <li>Production deployment feedback integration</li>
-        </ul>
-      </section>
     </section>
     
     <!-- introduction -->


### PR DESCRIPTION
## Summary

Fixes the ReSpec configuration to properly display version information using ReSpec's built-in versioning system instead of manual sections.

## Problem

The current spec has a manual "Version" section that duplicates information that ReSpec can handle automatically. This creates:
- Redundant version information
- Non-standard document structure  
- Maintenance overhead (version in multiple places)

## Solution

### ReSpec Configuration
- **Added `subtitle: 'Version 0.0.1'`** - Displays version prominently in document header
- **Added `latestVersion`** - Required for proper W3C Community Group document metadata

### Document Structure
- **Removed manual Version section** - Eliminates redundancy
- **Cleaner document flow** - Standard W3C spec structure: Abstract → SOTD → Introduction → Content

## Result

The specification now displays version information professionally in the ReSpec-generated header:
- **Title**: "Nostr DID Method Specification"
- **Subtitle**: "Version 0.0.1"
- **Status**: "Unofficial Draft [date]"

## Benefits

- **Standard compliance** - Follows W3C ReSpec best practices
- **Single source of truth** - Version only in respecConfig
- **Professional appearance** - Clean, standard document layout
- **Easy maintenance** - Future version updates only require changing respecConfig
- **No duplication** - Version information in one place

## Configuration

```javascript
const respecConfig = {
  specStatus: 'unofficial',
  group: 'nostr',
  subtitle: 'Version 0.0.1',
  latestVersion: 'https://nostrcg.github.io/did-nostr/',
  // ... rest of config
};
```

This approach aligns with how other W3C Community Group specifications handle versioning.

## Files Changed

- `index.html` - Updated respecConfig and removed manual Version section

## Impact

- ✅ Cleaner document structure
- ✅ Professional ReSpec versioning
- ✅ Easier version maintenance
- ✅ Standards compliance