### PR TITLE
Clarify timestamp field semantics and bump to v0.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
+        subtitle: 'Version 0.0.2',
+        latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {
             name: 'Melvin Carvalho',
@@ -314,8 +316,13 @@
     "timestamp": 1737906600
 }</pre>
         <p>
-          The <code>timestamp</code> field indicates when this profile data was fetched from relays (Unix seconds), 
-          allowing clients to determine data freshness and implement intelligent caching strategies.
+          The <code>timestamp</code> field contains the <code>created_at</code> value from the latest Nostr profile event (Unix seconds), 
+          allowing clients to determine profile freshness and implement intelligent caching strategies.
+        </p>
+        <p>
+          <strong>Note:</strong> For Nostr developers: the <code>timestamp</code> field contains the same value as 
+          <code>event.created_at</code> from the most recent kind 0 profile event. This allows clients to determine 
+          if their cached profile data is newer or older than what's in the DID document without querying relays.
         </p>
         <p>
           <strong>Note:</strong> While DID Core generally recommends against including personally identifiable information, 


### PR DESCRIPTION
Clarifies the timestamp field semantics in profile documentation and bumps to v0.0.2. The timestamp field now clearly contains the event.created_at from the latest Nostr profile event, enabling direct comparison with local cached data. Addresses #51.