### PR TITLE
Fix: Canonicalize relay URLs with trailing slash at origin

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
-        subtitle: 'Version 0.0.4',
+        subtitle: 'Version 0.0.5',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {
@@ -288,6 +288,7 @@
         <p>
           Each relay is represented as a service entry with type "Relay" and a
           serviceEndpoint that specifies the WebSocket URL of the relay.
+          Relay URLs at the origin level MUST include a trailing slash (e.g., <code>wss://relay.example.com/</code>).
           Multiple relays can be included in the service array.
         </p>
       </section>


### PR DESCRIPTION
## Summary

Fixes issue #35 by requiring relay URLs at the origin level to include a trailing slash for canonical representation.

## Problem

Currently, relay URLs can appear both with and without trailing slashes in DID documents:
- `wss://relay.example.com` 
- `wss://relay.example.com/`

This inconsistency causes:
- Duplicate relay entries in service arrays
- Unnecessary WebSocket reconnections
- Inconsistent handling across different implementations

## Solution

Add requirement that relay URLs at the origin level MUST include a trailing slash:

```json
{
  "type": "Relay",
  "serviceEndpoint": "wss://relay.example.com/"  // ✅ Canonical form
}
```

## Changes

- Added one line to Service Field for Relays section specifying trailing slash requirement
- Bumped version to 0.0.5
- Clarified this applies to origin-level URLs only (not paths)

## Technical Details

The requirement states:
> "Relay URLs at the origin level MUST include a trailing slash (e.g., `wss://relay.example.com/`)"

This aligns with:
- Standard URL canonicalization practices
- WebSocket client behavior
- Discussion in nostr-protocol/nips#1876

## Impact

- **No breaking changes** - Existing examples already use trailing slashes
- **Prevents bugs** - Eliminates duplicate entries and reconnection issues  
- **Clear specification** - Removes ambiguity for implementers

## Testing

- ✅ Verified existing examples follow this pattern
- ✅ Confirmed alignment with relay URL discussions
- ✅ No backwards compatibility issues

## References

- Fixes #35
- Related discussion: nostr-protocol/nips#1876

This is a small but important clarification that ensures consistent relay URL representation across the DID-Nostr ecosystem.