### PR TITLE
Add mandatory DIDNostr type field for linked data compliance

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
-        subtitle: 'Version 0.0.5',
+        subtitle: 'Version 0.0.6',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {
@@ -91,6 +91,11 @@
         </p>
 
         <p>
+          All DID documents MUST include a <code>type</code> field with the value <code>"DIDNostr"</code> 
+          to enable proper linked data processing and disambiguation per httpRange-14.
+        </p>
+
+        <p>
           Example Nostr DID:
           <code
             >did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code
@@ -137,6 +142,7 @@
 {
     "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
+    "type": "DIDNostr",
     "verificationMethod": [
         {
             "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
@@ -159,6 +165,7 @@
 {
     "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
+    "type": "DIDNostr",
     "verificationMethod": [
         {
             "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
@@ -188,6 +195,7 @@
 {
     "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
+    "type": "DIDNostr",
     "verificationMethod": [
         {
             "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1",
@@ -469,6 +477,7 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
             <li>Construct a DID Document with the following required properties:
               <ul>
                 <li>Set the <code>id</code> field to the full DID</li>
+                <li>Set the <code>type</code> field to <code>"DIDNostr"</code></li>
                 <li>Include a Multikey verification method, transforming the x-only public key following the multicodec/multibase encoding process</li>
                 <li>Set appropriate authentication and assertionMethod references to the verification method</li>
               </ul>


### PR DESCRIPTION
## Summary
- Adds mandatory `type: "DIDNostr"` field to all DID documents
- Enables proper linked data processing and httpRange-14 disambiguation 
- Updates all example DID documents and minimal resolution requirements
- Bumps version to 0.0.6

## Technical Details
The `type` field is now required for all DID documents to:
- Enable efficient SPARQL queries and RDF processing
- Provide clear semantic distinction between the DID document and the identity it describes
- Align with W3C linked data best practices where type-based dispatch is fundamental

## Examples
All DID document examples now include:
```json
{
  "id": "did:nostr:...",
  "type": "DIDNostr",
  ...
}
```

This change maintains backwards compatibility while adding semantic web compliance.