### PR TITLE
Fix DID Core section numbers in references

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,7 +573,7 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
         <p>
           For additional security requirements, refer to 
           <a href="https://www.w3.org/TR/did-core/#security-requirements">
-            W3C Decentralized Identifiers 7.3</a>.
+            W3C Decentralized Identifiers 8.3</a>.
         </p>
       </section>
       <section>
@@ -620,7 +620,7 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
         <p>
           For additional privacy requirements, refer to 
           <a href="https://www.w3.org/TR/did-core/#privacy-requirements">
-            W3C Decentralized Identifiers 7.4</a>.
+            W3C Decentralized Identifiers 8.4</a>.
         </p>
       </section>
     </section>


### PR DESCRIPTION
## Summary
Editorial fix for incorrect W3C DID Core section numbers in Security and Privacy requirements references.

Closes #21

## Changes
- ✅ **Security Requirements**: Updated from 7.3 → 8.3  
- ✅ **Privacy Requirements**: Updated from 7.4 → 8.4

## Type
**Class 1 Editorial Change** - Simple correction of reference numbers with no semantic impact.

## Impact
- Links continue to work correctly (URL fragments unchanged)
- Reference text now matches actual W3C DID Core v1.0 section numbers
- Improves document accuracy for readers cross-referencing sections