### PR TITLE
Add authors field to ReSpec configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
             url: 'https://melvincarvalho.com/#me'
           }
         ],
+        authors: [
+          {
+            name: 'Melvin Carvalho',
+            url: 'https://melvincarvalho.com/#me'
+          }
+        ],
         shortName: 'did-nostr',
         github: 'https://github.com/nostrcg/did-nostr',
         logos: [


### PR DESCRIPTION
## Summary
Adds the authors field to the ReSpec configuration following W3C specification authoring best practices.

Closes #18

## Changes
- ✅ **Single Author**: Added Melvin Carvalho as author
- ✅ **Maintains Editor**: Keeps single editor role unchanged
- ✅ **W3C Compliance**: Follows ReSpec documentation guidelines

## ReSpec Configuration
```javascript
editors: [
  {
    name: 'Melvin Carvalho',
    url: 'https://melvincarvalho.com/#me'
  }
],
authors: [
  {
    name: 'Melvin Carvalho',
    url: 'https://melvincarvalho.com/#me'
  }
]
```

## Rationale
Per W3C ReSpec best practices, specifications should have both editors and authors clearly identified. This establishes proper attribution and editorial responsibility for the specification.