### PR TITLE
Add block-core nostr-did-resolver to implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -699,6 +699,12 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
     <section>
       <h2>Implementations</h2>
       <p>
+        <a href="https://github.com/block-core/nostr-did-resolver">nostr-did-resolver</a> -
+        A TypeScript/JavaScript library for resolving did:nostr identifiers. This implementation
+        uses relay discovery to retrieve user relay lists (kind:10002) and profile metadata (kind:0),
+        with fallback to default relays. Maintained by <a href="https://github.com/block-core">block-core</a>.
+      </p>
+      <p>
         Block, Inc. previously developed a related implementation of the did:nostr method in Rust, but this work has been discontinued and archived. The archived repository can be found at
         <a href="https://github.com/TBD54566975/did-nostr"
           >https://github.com/TBD54566975/did-nostr</a


### PR DESCRIPTION
## Summary
- Add the actively maintained [nostr-did-resolver](https://github.com/block-core/nostr-did-resolver) TypeScript/JavaScript library to the Implementations section
- This implementation resolves did:nostr identifiers using relay discovery (kind:10002) and profile metadata (kind:0)
- Maintained by [block-core](https://github.com/block-core)

## Test plan
- [ ] Verify the link to the repository works
- [ ] Verify the spec renders correctly with ReSpec

Closes #33