### PR TITLE
fix: clean up implementations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,22 +703,17 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
       </p>
       <ul>
         <li>
-          <a href="https://nostr.rocks/.well-known/did/nostr/">nostr.rocks HTTP Resolver</a> - Production HTTP resolver implementing the <code>.well-known</code> path resolution method. Returns compliant DID documents with Multikey verification methods.
-        </li>
-        <li>
           <a href="https://nostrapps.github.io/did-explorer/">DID:nostr Explorer</a> (<a href="https://github.com/nostrapps/did-explorer">source</a>) - Web-based explorer for viewing DID documents, profiles, and follows. Demonstrates the spec in action with a visual interface.
         </li>
         <li>
-          <a href="https://github.com/block-core/nostr-did-resolver">nostr-did-resolver</a> - TypeScript/JavaScript library for resolving did:nostr identifiers using relay discovery.
+          <a href="https://nostr.rocks/.well-known/did/nostr/32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245.json">nostr.rocks HTTP Resolver</a> - Production HTTP resolver implementing the <code>.well-known</code> path resolution method. Returns compliant DID documents with Multikey verification methods.
+        </li>
+        <li>
+          <a href="https://github.com/block-core/nostr-did-resolver">nostr-did-resolver</a> - TypeScript/JavaScript library for resolving did:nostr identifiers using relay discovery. Maintained by block-core.
         </li>
       </ul>
-        <a href="https://github.com/block-core/nostr-did-resolver">nostr-did-resolver</a> -
-        A TypeScript/JavaScript library for resolving did:nostr identifiers. This implementation
-        uses relay discovery to retrieve user relay lists (kind:10002) and profile metadata (kind:0),
-        with fallback to default relays. Maintained by <a href="https://github.com/block-core">block-core</a>.
-      </p>
       <p>
-        Block, Inc. previously developed a related implementation of the did:nostr method in Rust, but this work has been discontinued and archived. The archived repository can be found at
+        Block, Inc. previously developed a related implementation in Rust, but this work has been discontinued. The archived repository can be found at
         <a href="https://github.com/TBD54566975/did-nostr"
           >https://github.com/TBD54566975/did-nostr</a
         >.


### PR DESCRIPTION
## Summary

Fixes issues in the implementations section from the previous merge:

1. **Reorder**: Explorer first (best visual showcase), then HTTP resolver
2. **Add example pubkey**: nostr.rocks link now points to jb55's DID document
3. **Remove duplicate**: nostr-did-resolver was listed twice
4. **Fix HTML**: Removed orphaned text outside the list

## Changes

```
- DID:nostr Explorer (first - best showcase)
- nostr.rocks HTTP Resolver (with example link)
- nostr-did-resolver (single entry)
```