### PR TITLE
Add create-agent to implementations list

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,6 +711,9 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
         <li>
           <a href="https://github.com/block-core/nostr-did-resolver">nostr-did-resolver</a> - TypeScript/JavaScript library for resolving did:nostr identifiers using relay discovery. Maintained by block-core.
         </li>
+        <li>
+          <a href="https://www.npmjs.com/package/create-agent">create-agent</a> (<a href="https://github.com/melvincarvalho/create-agent">source</a>) - CLI tool and library for generating did:nostr identities. Available via <code>npx create-agent</code>.
+        </li>
       </ul>
       <p>
         Block, Inc. previously developed a related implementation in Rust, but this work has been discontinued. The archived repository can be found at


### PR DESCRIPTION
Adds [create-agent](https://github.com/melvincarvalho/create-agent) to the implementations section.

## About create-agent

- **npm**: https://www.npmjs.com/package/create-agent
- **Usage**: `npx create-agent`
- **License**: MIT

CLI tool and library for generating spec-compliant did:nostr identities with:
- Nostr keypairs (privkey, pubkey, nsec, npub)
- Multikey verification method
- Correct `publicKeyMultibase` encoding

Closes #79