### PR TITLE
Review and fix normative language (RFC 2119)

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <p>
           The Nostr DID scheme `did:nostr:pubkey` is based on the encoding of a
           public key. The public key is represented as a 64-character, lowercase
-          string. The prefix <code>did:nostr</code> should be in lowercase, as
+          string. The prefix <code>did:nostr</code> SHOULD be in lowercase, as
           per the DID specification.
         </p>
 
@@ -285,8 +285,8 @@
         
         <p>
           <strong>Note on Parity Bytes:</strong> While most implementations default to the 0x02 prefix 
-          for even y-coordinates, Nostr applications may generate keys with either 0x02 or 0x03 prefixes. 
-          Implementations should handle both cases when constructing the compressed public key format.
+          for even y-coordinates, Nostr applications may generate keys with either 0x02 or 0x03 prefixes.
+          Implementations SHOULD handle both cases when constructing the compressed public key format.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
Reviewed normative language usage throughout the spec per RFC 2119 and fixed two instances:

- Changed "should be in lowercase" to "SHOULD" in DID scheme section (line 95)
- Changed "should handle both cases" to "SHOULD" in Multikey section (line 289)

Other lowercase "should/may" instances are in informative/explanatory contexts (security considerations, privacy considerations) where they are appropriate.

Fixes #82