### PR TITLE
Validate external links and add BIP-340 reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,6 +659,9 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
           <a href="https://github.com/nostr-protocol/nips">Nostr Implementation Possibilities (NIPs)</a> - Nostr protocol extension proposals
         </li>
         <li>
+          <a href="https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki">BIP-340</a> - Schnorr Signatures for secp256k1
+        </li>
+        <li>
           <a href="https://www.rfc-editor.org/rfc/rfc6979">RFC 6979</a> - Deterministic Usage of the Digital Signature Algorithm (DSA) and Elliptic Curve Digital Signature Algorithm (ECDSA)
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- Validated all external links in the specification (all return HTTP 200)
- Added missing BIP-340 reference to Resources section

## Links Validated
| Status | URL |
|--------|-----|
| 200 | https://github.com/nostr-protocol/nostr |
| 200 | https://www.w3.org/community/nostr/ |
| 200 | https://github.com/nostrcg/did-nostr |
| 200 | https://www.w3.org/TR/did-core/ |
| 200 | https://github.com/TBD54566975/did-nostr (archived - correct) |
| 200 | https://github.com/nostr-protocol/nips |
| 200 | https://www.rfc-editor.org/rfc/rfc6979 |
| 200 | https://w3id.org/did |
| 200 | https://w3id.org/nostr/context |

## Added
- BIP-340 reference (Schnorr Signatures for secp256k1)

Fixes #83