### PR TITLE
Use the CID v1.0 `@context` so `Multikey`/`publicKeyMultibase` are defined (#90)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,15 @@
         ],
         lint: {
           "no-unused-dfns": false
+        },
+        localBiblio: {
+          "CID": {
+            title: "Controlled Identifiers (CIDs) v1.0",
+            href: "https://www.w3.org/TR/cid-1.0/",
+            status: "REC",
+            publisher: "W3C",
+            date: "2025-05-15"
+          }
         }
       }
     </script>
@@ -146,7 +155,7 @@
           <p>The following minimal DID document can be generated from the public key alone, without network access:</p>
           <pre class="example">
 {
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -174,7 +183,7 @@
           <p>When enhanced through relay queries, additional service endpoints can be included:</p>
           <pre class="example">
 {
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -209,7 +218,7 @@
           <p>A fully enhanced DID document can include profile information and social relationships:</p>
           <pre class="example">
 {
-    "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -264,7 +273,10 @@
           Nostr DIDs use the Multikey verification method to provide a standardized way to encode 
           secp256k1 public keys for Data Integrity implementations. This method transforms the x-only 
           BIP-340 public key from the DID identifier into a format compatible with W3C Verifiable 
-          Credentials Data Integrity specifications.
+          Credentials Data Integrity specifications. The <code>Multikey</code> type and the
+          <code>publicKeyMultibase</code> property are defined by Controlled Identifiers v1.0 [[CID]];
+          accordingly, DID documents include <code>https://www.w3.org/ns/cid/v1</code> in their
+          <code>@context</code> so that these terms are well defined under JSON-LD processing.
         </p>
         
         <p>
@@ -731,6 +743,9 @@ Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
         </li>
         <li>
           <a href="https://www.w3.org/TR/did-core/">W3C Decentralized Identifiers (DIDs) v1.0</a> - The W3C Recommendation for Decentralized Identifiers
+        </li>
+        <li>
+          <a href="https://www.w3.org/TR/cid-1.0/">W3C Controlled Identifiers (CIDs) v1.0</a> - The W3C Recommendation defining the <code>Multikey</code> verification method and <code>publicKeyMultibase</code>
         </li>
         <li>
           <a href="https://github.com/nostrcg/did-nostr">DID:Nostr Method GitHub Repository</a> - Source code and issue tracker for this specification


### PR DESCRIPTION
Closes #90.

DID documents in the spec use `"type": "Multikey"` with `publicKeyMultibase`, but the declared `@context` (`https://w3id.org/did` + `https://w3id.org/nostr/context`) defines neither term, and `https://w3id.org/did` returns `text/html` rather than a JSON-LD context. So the documents do not fully JSON-LD-expand.

This swaps the broken DID-core context for the **Controlled Identifiers v1.0** context, the only W3C context that defines `Multikey` and `publicKeyMultibase`:

```
- "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"]
+ "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"]
```

It also adds CID v1.0 (a W3C Recommendation, 2025-05-15) to the references and cites it where the Multikey method is introduced.

**Why two contexts (cid/v1 + nostr/context), not three**

- `https://www.w3.org/ns/cid/v1` already defines every controller-document term these DID documents use (`id`, `controller`, `verificationMethod`, `authentication`, `assertionMethod`, `service`, `alsoKnownAs`, `type`) plus `Multikey` and `publicKeyMultibase`. Verified against the live context.
- This matches **did:key**, which uses the single `https://www.w3.org/ns/did/v1.1` context — byte-identical to `cid/v1` — for exactly this `Multikey`/`publicKeyMultibase` shape.
- For reviewers who prefer also keeping a DID-core context, `["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"]` is also conflict-free: the shared `@protected` terms between `did/v1` and `cid/v1` are defined identically (checked term-by-term), so no protected-term redefinition error.

**Scope:** term-definition / `@context` only. The separate parity-byte determinism question (the "SHOULD handle both cases" note) is left to its own issue/PR.

Checks anyone can run:

```
curl -sL https://www.w3.org/ns/cid/v1 | grep -o '"Multikey"'         # defined
curl -sL -o /dev/null -w '%{content_type}\n' https://w3id.org/did    # text/html, not a JSON-LD context
```