### PR TITLE
Document parity rationale (key tweaking) and Multikey provenance (#254)

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,20 @@
           <strong>Note on Parity Bytes:</strong> While most implementations default to the 0x02 prefix 
           for even y-coordinates, Nostr applications may generate keys with either 0x02 or 0x03 prefixes.
           Implementations SHOULD handle both cases when constructing the compressed public key format.
+          Both parities occur in practice because a key may be derived by tweaking. For example, taproot
+          or <a href="https://blocktrails.org/">blocktrails</a> key-chaining adds a scalar to the key at
+          each step, so the resulting point's y-coordinate parity is not predictable in advance and the
+          true parity MUST be carried rather than assumed to be even.
+        </p>
+        <p>
+          The <code>Multikey</code> representation (rather than a raw-hex sibling encoding) was adopted
+          following cross-Community-Group discussion in
+          <a href="https://github.com/w3c-ccg/community/issues/254">w3c-ccg/community#254</a> (Data
+          Integrity BIP340 Cryptosuite); see the
+          <a href="https://lists.w3.org/Archives/Public/public-credentials/2025Aug/0014.html">CCG
+          mailing-list rationale</a>. The DID identifier remains the raw lowercase hexadecimal public
+          key; the verification method uses <code>Multikey</code> for compatibility with W3C Data
+          Integrity tooling.
         </p>
       </section>
 


### PR DESCRIPTION
Two non-normative rationale additions to the Multikey Verification Method section. Complements #90/#91 (which fix the `@context`); kept separate so each PR is one concern.

1. **Why both `0x02`/`0x03` parities occur.** The spec already says implementations must handle both, but not *why*. Added: a key may be derived by **tweaking** (taproot / blocktrails key-chaining adds a scalar at each step), so the resulting point's y-parity is not predictable in advance and the true parity must be carried rather than assumed even. This documents the connection to the broader single-use-seal / blocktrails layer.

2. **Provenance for choosing `Multikey`.** Links the cross-CG resolution in w3c-ccg/community#254 (Data Integrity BIP340 Cryptosuite) and the CCG mailing-list rationale, recording that `Multikey` (not a raw-hex sibling encoding) was a debated, settled decision; the DID identifier stays raw hex while the verification method uses `Multikey`.

No normative changes; no example/`@context` changes (those are in #91).