### PR TITLE
Bump version to 0.0.11

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
-        subtitle: 'Version 0.0.10',
+        subtitle: 'Version 0.0.11',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {


### PR DESCRIPTION
Closes #98.

Bumps the ReSpec `subtitle` from `Version 0.0.10` to `Version 0.0.11`.

## Changelog (0.0.10 -> 0.0.11)

- **CID v1.0 `@context`** (#91, closes #90): DID document examples use `https://www.w3.org/ns/cid/v1` so `Multikey` / `publicKeyMultibase` are defined; adds `localBiblio` for `[[CID]]`, Multikey-section rationale, and CID v1.0 in Resources.
- **Vendored ReSpec same-origin** (#96, closes #95): ships `respec-w3c.js` locally so the spec renders in browsers that block the cross-origin ReSpec script.