### PR TITLE
Add in-graph `modified` provenance field, drop `Nostr-Timestamp` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ When a Nostr DID is resolved, it produces a DID Document like this:
   "follows": [
     "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
     "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
-  ]
+  ],
+  "modified": "2025-01-26T15:30:00Z"
 }
 ```
 
@@ -95,6 +96,7 @@ These documents define:
 - **Optional service endpoints** for Nostr relays (URLs at origin level MUST include trailing slash)
 - **Optional profile information** from kind 0 Nostr events with timestamp for freshness
 - **Optional social graph** with follows array derived from kind 3 contact lists
+- **DID subject change time** via `modified` (most recent `created_at` across signed parts) for staleness detection and safe cross-app writes
 
 ## Resolution Methods
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When a Nostr DID is resolved, it produces a DID Document like this:
 
 ```json
 {
-  "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
+  "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
   "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
   "type": "DIDNostr",
   "verificationMethod": [
@@ -54,7 +54,7 @@ When a Nostr DID is resolved, it produces a DID Document like this:
 
 ```json
 {
-  "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
+  "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
   "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
   "type": "DIDNostr",
   "verificationMethod": [

--- a/index.html
+++ b/index.html
@@ -502,25 +502,15 @@
         </p>
         <p>
           Because the value is derived solely from the signed source events, every mirror computes the same
-          <code>modified</code> for the same state. It is part of the document graph (not an HTTP header), so
-          it is signable, content-addressed, and mirror-independent. Only changes to signed subject data
-          affect it; resolver- or representation-level changes (which mirror served the document, formatting)
-          do not, and are conveyed instead by the <code>ETag</code> / <code>Last-Modified</code> HTTP headers.
+          <code>modified</code> for the same state, and only changes to signed subject data affect it.
         </p>
         <p>
-          The <code>modified</code> field lets a consumer detect staleness and avoid overwriting newer state
-          with older &mdash; for example, an application about to publish a follow list can compare its cached
-          kind&nbsp;3 <code>created_at</code> against the document's <code>modified</code> and re-fetch before
-          writing rather than silently replacing a newer list. A consumer performing such an anti-overwrite
-          check MUST NOT treat a missing <code>modified</code> as authoritative evidence that its cached copy
-          is current; absence means the change time is unknown, and the consumer MUST fall back to its
-          conservative path.
-        </p>
-        <p>
-          <strong>Note:</strong> The subject-level <code>modified</code> is distinct from the part-level
-          <code>profile.timestamp</code>: <code>modified</code> is an ISO&nbsp;8601 aggregate over all signed
-          parts, while <code>profile.timestamp</code> remains the kind&nbsp;0 <code>created_at</code> in Unix
-          seconds. They coincide only when the profile is the most recently changed part.
+          This lets a consumer detect staleness and avoid overwriting newer state with older &mdash; for
+          example, an application about to publish a follow list can compare its cached kind&nbsp;3
+          <code>created_at</code> against the document's <code>modified</code> and re-fetch before writing.
+          A consumer performing such a check MUST NOT treat a missing <code>modified</code> as evidence that
+          its cached copy is current; absence means the change time is unknown, and the consumer MUST fall
+          back to its conservative path.
         </p>
       </section>
     </section>
@@ -583,18 +573,12 @@
 Cache-Control: max-age=3600
 Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
           <p>
-            Servers SHOULD include an <code>ETag</code> as an opaque validator for the exact document
-            representation, enabling standard <code>If-None-Match</code> conditional requests. The
-            <code>ETag</code> changes whenever the served bytes change, so it captures representation-level
-            changes (including resolver- or mirror-specific differences) that the in-graph
-            <code>modified</code> field deliberately does not. Its computation basis is
-            implementation-defined.
-          </p>
-          <p>
-            Freshness of the subject's signed state is conveyed in-document by the <code>modified</code>
-            field (see <a href="#modified-field">Modified Field</a>), which is mirror-independent and covered
-            by the document hash. Earlier drafts defined a <code>Nostr-Timestamp</code> header for this
-            purpose; it is removed in favor of in-graph <code>modified</code>.
+            Servers SHOULD include an <code>ETag</code> as an opaque validator for the document
+            representation, enabling standard <code>If-None-Match</code> conditional requests; its computation
+            basis is implementation-defined. The <code>ETag</code> changes whenever the served bytes change,
+            so it captures representation-level differences (such as which mirror served the document) that
+            the in-graph <a href="#modified-field"><code>modified</code></a> field does not. The earlier
+            <code>Nostr-Timestamp</code> header is removed in favor of <code>modified</code>.
           </p>
           <p>
             This enables fast, cacheable resolution without requiring cryptographic computation or relay queries. Servers can serve minimal documents for offline-first scenarios or enhanced documents with service endpoints and profile metadata.

--- a/index.html
+++ b/index.html
@@ -258,7 +258,8 @@
     "follows": [
         "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
         "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
-    ]
+    ],
+    "modified": "2025-01-26T15:30:00Z"
 }
   </pre>
           <p>This complete document enables social applications to resolve identity, profile, relays, and social graph information in a single operation.</p>
@@ -408,8 +409,10 @@
     "timestamp": 1737906600
 }</pre>
         <p>
-          The <code>timestamp</code> field contains the <code>created_at</code> value from the latest Nostr profile event (Unix seconds), 
-          allowing clients to determine profile freshness and implement intelligent caching strategies.
+          The <code>timestamp</code> field contains the <code>created_at</code> value from the latest Nostr profile event (Unix seconds),
+          allowing clients to determine profile freshness and implement intelligent caching strategies. It is the
+          part-level provenance for the profile; the document-level aggregate across all signed parts is the
+          <a href="#modified-field"><code>modified</code></a> field.
         </p>
         <p>
           <strong>Note:</strong> For Nostr developers: the <code>timestamp</code> field contains the same value as 
@@ -481,6 +484,45 @@
           addresses the scalability challenge shared with other social protocols like ActivityPub.
         </p>
       </section>
+
+      <section id="modified-field">
+        <h3>Modified Field (Document Provenance)</h3>
+        <p>
+          A DID Document that composes signed parts (profile, follows, relays) SHOULD include a
+          <code>modified</code> field giving the document's most recent change time:
+        </p>
+        <pre class="example">
+"modified": "2025-01-26T15:30:00Z"</pre>
+        <p>
+          The <code>modified</code> field is the surface form of <code>dcterms:modified</code> (defined in
+          the <code>did:nostr</code> context, typed as <code>xsd:dateTime</code>). Its value is the most
+          recent <code>created_at</code> across all signed parts composed into the document &mdash; that is,
+          <code>max(created_at)</code> over the source kind&nbsp;0 (profile), kind&nbsp;3 (follows), and
+          kind&nbsp;10002 (relays) events &mdash; serialized as an ISO&nbsp;8601 UTC timestamp.
+        </p>
+        <p>
+          Because the value is derived solely from the signed source events, every mirror computes the same
+          <code>modified</code> for the same state. It is part of the document graph (not an HTTP header), so
+          it is signable, content-addressed, and mirror-independent. Only changes to signed subject data
+          affect it; resolver- or representation-level changes (which mirror served the document, formatting)
+          do not, and are conveyed instead by the <code>ETag</code> / <code>Last-Modified</code> HTTP headers.
+        </p>
+        <p>
+          The <code>modified</code> field lets a consumer detect staleness and avoid overwriting newer state
+          with older &mdash; for example, an application about to publish a follow list can compare its cached
+          kind&nbsp;3 <code>created_at</code> against the document's <code>modified</code> and re-fetch before
+          writing rather than silently replacing a newer list. A consumer performing such an anti-overwrite
+          check MUST NOT treat a missing <code>modified</code> as authoritative evidence that its cached copy
+          is current; absence means the change time is unknown, and the consumer MUST fall back to its
+          conservative path.
+        </p>
+        <p>
+          <strong>Note:</strong> The subject-level <code>modified</code> is distinct from the part-level
+          <code>profile.timestamp</code>: <code>modified</code> is an ISO&nbsp;8601 aggregate over all signed
+          parts, while <code>profile.timestamp</code> remains the kind&nbsp;0 <code>created_at</code> in Unix
+          seconds. They coincide only when the profile is the most recently changed part.
+        </p>
+      </section>
     </section>
     <section id="conformance">
       <p>
@@ -537,11 +579,22 @@
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:
           </p>
-          <pre><code>Nostr-Timestamp: 1737906600
+          <pre><code>ETag: "9f2c1d8a7b3e4f06"
 Cache-Control: max-age=3600
 Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
           <p>
-            The <code>Nostr-Timestamp</code> header contains the Unix timestamp when the DID document was generated or refreshed. This enables clients to check freshness without parsing the JSON body, allowing for efficient caching strategies.
+            Servers SHOULD include an <code>ETag</code> as an opaque validator for the exact document
+            representation, enabling standard <code>If-None-Match</code> conditional requests. The
+            <code>ETag</code> changes whenever the served bytes change, so it captures representation-level
+            changes (including resolver- or mirror-specific differences) that the in-graph
+            <code>modified</code> field deliberately does not. Its computation basis is
+            implementation-defined.
+          </p>
+          <p>
+            Freshness of the subject's signed state is conveyed in-document by the <code>modified</code>
+            field (see <a href="#modified-field">Modified Field</a>), which is mirror-independent and covered
+            by the document hash. Earlier drafts defined a <code>Nostr-Timestamp</code> header for this
+            purpose; it is removed in favor of in-graph <code>modified</code>.
           </p>
           <p>
             This enables fast, cacheable resolution without requiring cryptographic computation or relay queries. Servers can serve minimal documents for offline-first scenarios or enhanced documents with service endpoints and profile metadata.

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
         <p>
           The <code>timestamp</code> field contains the <code>created_at</code> value from the latest Nostr profile event (Unix seconds),
           allowing clients to determine profile freshness and implement intelligent caching strategies. It is the
-          part-level provenance for the profile; the document-level aggregate across all signed parts is the
+          part-level provenance for the profile; the subject-level aggregate across all signed parts is the
           <a href="#modified-field"><code>modified</code></a> field.
         </p>
         <p>
@@ -486,10 +486,10 @@
       </section>
 
       <section id="modified-field">
-        <h3>Modified Field (Document Provenance)</h3>
+        <h3>Modified Field (DID Subject Provenance)</h3>
         <p>
           A DID Document that composes signed parts (profile, follows, relays) SHOULD include a
-          <code>modified</code> field giving the document's most recent change time:
+          <code>modified</code> field giving the DID subject's most recent change time:
         </p>
         <pre class="example">
 "modified": "2025-01-26T15:30:00Z"</pre>


### PR DESCRIPTION
Implements the provenance model agreed in #106.

## What changes
- **New `modified` field** (document-level): surface form of `dcterms:modified` (typed `xsd:dateTime`), value = `max(created_at)` over the signed parts (kind 0 profile / kind 3 follows / kind 10002 relays), serialized ISO 8601. Source-derived, so every mirror computes the same value; in-graph, so it is signable and covered by the document hash.
- **Drop the `Nostr-Timestamp` header** → generic `ETag` recommendation (representation validator for `If-None-Match`; computation basis left implementation-defined). Subject freshness now lives in-graph via `modified`; `ETag`/`Last-Modified` cover representation-level changes.
- **New "Modified Field" section** with the use case (anti-overwrite of follow lists, #107) and normative language: producer **SHOULD** include `modified` when composing signed parts; a consumer doing an anti-overwrite check **MUST NOT** treat a missing `modified` as current (absence = unknown → stay conservative).
- **Cross-reference** from `profile.timestamp` to the document-level aggregate.

## Not changed (deliberately)
- `follows` / `relays` shape (per-part provenance deferred per #106) → existing test vectors untouched.
- `profile.timestamp` value/format (kind 0 `created_at`, Unix seconds).
- ETag basis (parked) and blocktrails (deferred).

## Dependency
Requires the `modified` term in the shared context — added and deployed in nostrcg/schema#24 (now live at `nostrcg.github.io/schema/context.jsonld`).

Closes #106.