### PR TITLE
Specify identifier must be a valid secp256k1 x-only key (#105)

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,15 @@
         </p>
 
         <p>
+          A conformant <code>did:nostr</code> identifier MUST be a valid secp256k1 x-only public key: its
+          32-byte value MUST be a field element (<code>x &lt; p</code>, where <code>p</code> is the secp256k1
+          field prime) and the x-coordinate of a point on the curve. Resolvers SHOULD validate the
+          identifier; the key transformation and minimal resolution MAY treat a presumed-valid identifier as
+          opaque hexadecimal, so offline resolution need not perform elliptic-curve arithmetic on
+          already-trusted input.
+        </p>
+
+        <p>
           All DID documents MUST include a <code>type</code> field with the value <code>"DIDNostr"</code> 
           to enable proper linked data processing and disambiguation per httpRange-14.
         </p>


### PR DESCRIPTION
Closes #105.

Resolves the normative gap surfaced by the #101 conformance vectors: the spec did not say whether a `did:nostr` identifier must be a *valid* secp256k1 x-only key or merely a 64-char hex string (the `all_ones` vector has `x ≥ p`, not a valid field element).

Adds one paragraph to the Nostr DID Scheme section:
- A conformant identifier **MUST** be a valid secp256k1 x-only public key — `x < p` and the x-coordinate of a point on the curve.
- Resolvers **SHOULD** validate the identifier.
- The key transformation and minimal resolution **MAY** treat a presumed-valid identifier as opaque hex, so offline resolution need not do elliptic-curve arithmetic on already-trusted input.

This keeps the cheap string-encoding path available while making validity a conformance requirement (the issue's recommended position).

Follow-on (not in this PR): #101's boundary vectors get relabeled (`all_ones`/`all_zeros` as opaque-encoder cases) and an `InvalidPublicKey` error vector added — to regenerate once this lands.