### PR TITLE
Bump version to 0.0.12

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       const respecConfig = {
         specStatus: 'unofficial',
         group: 'nostr',
-        subtitle: 'Version 0.0.11',
+        subtitle: 'Version 0.0.12',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {


### PR DESCRIPTION
Tags the cleaned-up spec as 0.0.12. This release closes out a batch of 0.0.11 fixes:

- #106 — in-graph `modified` provenance field; `Nostr-Timestamp` header removed (#103)
- #105 — identifier must be a valid secp256k1 x-only key (x < p, on-curve)
- #117 — `profile.timestamp` → `profile.created_at` (resolves the `timestamp` half of #93)
- #92 / #118 — Multikey provenance + proper parity spec text
- #102 — standalone parity model explainer (`parity-model.md`)

The #101 conformance suite is already regenerated for 0.0.12 and will land alongside (pending two small vector fixes under review).