### PR TITLE
Use relative key references (#key1) in conformance vectors (#128)

### DIFF
--- a/test-vectors/test-vectors-generated.json
+++ b/test-vectors/test-vectors-generated.json
@@ -136,10 +136,10 @@
             "https://w3id.org/nostr/context"
           ],
           "assertionMethod": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "authentication": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
           "type": "DIDNostr",
@@ -163,10 +163,10 @@
             "https://w3id.org/nostr/context"
           ],
           "assertionMethod": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "authentication": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
           "modified": "2025-01-26T15:30:00Z",
@@ -208,10 +208,10 @@
             "at://alice.bsky.social"
           ],
           "assertionMethod": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "authentication": [
-            "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#key1"
+            "#key1"
           ],
           "follows": [
             "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",


### PR DESCRIPTION
Per #128: the `did_document_generation` vectors used **absolute** DID URLs for `authentication`/`assertionMethod`, while the spec examples and Beacon use **relative** `#key1`. This aligns the vectors to relative refs (VM `id`/`controller` stay absolute).

Surfaced by an independent clean-room resolver: it passes 18/21 vectors, with the 3 doc-generation vectors blocked only by this mismatch.

cc @amir-hameed-mir — this is a hand-patch of the generated file; `nostr-did` should emit relative `#key1` on the next regen so it stays the source of truth. Decision + rationale in #128.