### PR TITLE
Fix modified example value (15:30 -> 15:50) + complete-vector relay id (#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When a Nostr DID is resolved, it produces a DID Document like this:
     "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
     "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
   ],
-  "modified": "2025-01-26T15:30:00Z"
+  "modified": "2025-01-26T15:50:00Z"
 }
 ```
 

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
         "did:nostr:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
         "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
     ],
-    "modified": "2025-01-26T15:30:00Z"
+    "modified": "2025-01-26T15:50:00Z"
 }
   </pre>
           <p>This complete document enables social applications to resolve identity, profile, relays, and social graph information in a single operation.</p>
@@ -507,7 +507,7 @@
           <code>modified</code> field giving the DID subject's most recent change time:
         </p>
         <pre class="example">
-"modified": "2025-01-26T15:30:00Z"</pre>
+"modified": "2025-01-26T15:50:00Z"</pre>
         <p>
           The <code>modified</code> field is the surface form of <code>dcterms:modified</code> (defined in
           the <code>did:nostr</code> context, typed as <code>xsd:dateTime</code>). Its value is the most
@@ -586,7 +586,7 @@
           </p>
           <pre><code>ETag: "9f2c1d8a7b3e4f06"
 Cache-Control: max-age=3600
-Last-Modified: Sun, 26 Jan 2025 15:30:00 GMT</code></pre>
+Last-Modified: Sun, 26 Jan 2025 15:50:00 GMT</code></pre>
           <p>
             Servers SHOULD include an <code>ETag</code> as an opaque validator for the document
             representation, enabling standard <code>If-None-Match</code> conditional requests; its computation

--- a/test-vectors/test-vectors-generated.json
+++ b/test-vectors/test-vectors-generated.json
@@ -169,7 +169,7 @@
             "#key1"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-          "modified": "2025-01-26T15:30:00Z",
+          "modified": "2025-01-26T15:50:00Z",
           "service": [
             {
               "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
@@ -218,7 +218,7 @@
             "did:nostr:46fcbe3065eaf1ae7811465924e48923363ff3f526bd6f73d7c184147700e3a8"
           ],
           "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
-          "modified": "2025-01-26T15:30:00Z",
+          "modified": "2025-01-26T15:50:00Z",
           "profile": {
             "about": "Building the decentralized web",
             "created_at": 1737906600,
@@ -230,7 +230,7 @@
           },
           "service": [
             {
-              "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay",
+              "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2#relay1",
               "serviceEndpoint": "wss://relay.damus.io/",
               "type": "Relay"
             }


### PR DESCRIPTION
Closes #131. `created_at = 1737906600` is **2025-01-26T15:50:00Z**, not 15:30:00Z (that's `1737905400`, 20 min earlier). The wrong literal was propagated across the spec (`index.html` ×3, incl. the `Last-Modified` example), the README, and the conformance vectors (enhanced + complete).

Also aligns the complete vector's service id `#relay` -> `#relay1` (the enhanced vector, Beacon, and the resolver all use the indexed form).

Surfaced by the clean-room resolver, which **computes** `modified` from `max(created_at)` and produced 15:50.

cc @amir-hameed-mir — the durable fix is for `nostr-did` to **compute** `modified` (not hardcode it) so it can't drift from `created_at`; with that, the regenerated vectors will match.