### PR TITLE
Pre-0.1 spec batch: normative .well-known, relative refs, Update/Delete reframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@ Last-Modified: Sun, 26 Jan 2025 15:50:00 GMT</code></pre>
       </section>
 
       <section>
-        <h3>Deactivate (Revoke)</h3>
+        <h3>Deactivate</h3>
         <p>
           This version of the method defines no native mechanism for key rotation or deactivation: if the
           controller's key is lost or compromised, there is no in-method recovery. Defining rotation and

--- a/index.html
+++ b/index.html
@@ -581,8 +581,10 @@
           <p>
             where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
             ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
-            or enhanced) with media type <code>application/did+json</code>, or
-            <code>application/did+ld+json</code> for the JSON-LD representation these documents use.
+            or enhanced). <code>did:nostr</code> documents are JSON-LD (they include a <code>@context</code>),
+            so the canonical representation media type is <code>application/did+ld+json</code>; servers MAY
+            also serve the document as <code>application/did+json</code> for compatibility with tooling that
+            expects the plain-JSON DID media type.
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:

--- a/index.html
+++ b/index.html
@@ -575,11 +575,13 @@
         <section>
           <h4>HTTP Resolution</h4>
           <p>
-            Servers can host complete DID documents at:
+            The HTTP representation of a <code>did:nostr</code> document MUST be located at:
           </p>
-          <pre><code>https://example.com/.well-known/did/nostr/&lt;pubkey&gt;.json</code></pre>
+          <pre><code>https://&lt;domain&gt;/.well-known/did/nostr/&lt;pubkey&gt;.json</code></pre>
           <p>
-            Where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hex public key. The endpoint SHOULD return a complete DID document (minimal or enhanced).
+            where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
+            ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
+            or enhanced) with media type <code>application/did+json</code>.
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:
@@ -618,7 +620,7 @@ Last-Modified: Sun, 26 Jan 2025 15:50:00 GMT</code></pre>
                 <li>Set the <code>id</code> field to the full DID</li>
                 <li>Set the <code>type</code> field to <code>"DIDNostr"</code></li>
                 <li>Include a Multikey verification method, transforming the x-only public key following the multicodec/multibase encoding process</li>
-                <li>Set appropriate authentication and assertionMethod references to the verification method</li>
+                <li>Set <code>authentication</code> and <code>assertionMethod</code> to reference the verification method using a relative DID URL (<code>#key1</code>); the verification method's own <code>id</code> and <code>controller</code> remain absolute</li>
               </ul>
             </li>
           </ol>
@@ -661,13 +663,21 @@ Last-Modified: Sun, 26 Jan 2025 15:50:00 GMT</code></pre>
 
       <section>
         <h3>Update (Replace)</h3>
-        <p>This DID Method does not support updating the DID Document.</p>
+        <p>
+          The <code>did:nostr</code> identifier is permanent: the key-to-DID binding cannot be changed.
+          The DID document, however, is a projection of signed Nostr events and is updated through the event
+          layer &mdash; publishing a newer kind 0 (profile), kind 3 (follows), or kind 10002 (relays) event
+          changes what the document projects on the next resolution. The in-graph
+          <a href="#modified-field"><code>modified</code></a> field reflects the most recent such change.
+        </p>
       </section>
 
       <section>
-        <h3>Delete (Revoke)</h3>
+        <h3>Deactivate (Revoke)</h3>
         <p>
-          This DID Method does not support deactivating the DID Document.
+          This version of the method defines no native mechanism for key rotation or deactivation: if the
+          controller's key is lost or compromised, there is no in-method recovery. Defining rotation and
+          deactivation semantics is an open item and is expected in a future revision.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -581,7 +581,8 @@
           <p>
             where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
             ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
-            or enhanced) with media type <code>application/did+json</code>.
+            or enhanced) with media type <code>application/did+json</code>, or
+            <code>application/did+ld+json</code> for the JSON-LD representation these documents use.
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:
@@ -666,7 +667,7 @@ Last-Modified: Sun, 26 Jan 2025 15:50:00 GMT</code></pre>
         <p>
           The <code>did:nostr</code> identifier is permanent: the key-to-DID binding cannot be changed.
           The DID document, however, is a projection of signed Nostr events and is updated through the event
-          layer &mdash; publishing a newer kind 0 (profile), kind 3 (follows), or kind 10002 (relays) event
+          layer &mdash; publishing a newer kind 0 (profile), kind 3 (contact list), or kind 10002 (relays) event
           changes what the document projects on the next resolution. The in-graph
           <a href="#modified-field"><code>modified</code></a> field reflects the most recent such change.
         </p>

--- a/index.html
+++ b/index.html
@@ -581,10 +581,9 @@
           <p>
             where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
             ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
-            or enhanced). <code>did:nostr</code> documents are JSON-LD (they include a <code>@context</code>),
-            so the canonical representation media type is <code>application/did+ld+json</code>; servers MAY
-            also serve the document as <code>application/did+json</code> for compatibility with tooling that
-            expects the plain-JSON DID media type.
+            or enhanced). These documents are JSON-LD &mdash; they include a <code>@context</code> &mdash; so
+            <code>application/ld+json</code> is the natural media type; for compatibility with DID tooling,
+            <code>application/did+json</code> (and <code>application/did+ld+json</code>) are equally acceptable.
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:

--- a/index.html
+++ b/index.html
@@ -581,9 +581,10 @@
           <p>
             where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
             ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
-            or enhanced). These documents are JSON-LD &mdash; they include a <code>@context</code> &mdash; so
-            <code>application/ld+json</code> is the natural media type; for compatibility with DID tooling,
-            <code>application/did+json</code> (and <code>application/did+ld+json</code>) are equally acceptable.
+            or enhanced). These documents are JSON &mdash; and, via their <code>@context</code>, JSON-LD &mdash;
+            so <code>application/json</code> and <code>application/ld+json</code> apply; for compatibility with
+            DID tooling, <code>application/did+json</code> (and <code>application/did+ld+json</code>) are
+            equally acceptable.
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:

--- a/index.html
+++ b/index.html
@@ -581,10 +581,9 @@
           <p>
             where <code>&lt;pubkey&gt;</code> is the 64-character lowercase hexadecimal public key and the path
             ends in the <code>.json</code> suffix. The endpoint SHOULD return a complete DID document (minimal
-            or enhanced). These documents are JSON &mdash; and, via their <code>@context</code>, JSON-LD &mdash;
-            so <code>application/json</code> and <code>application/ld+json</code> apply; for compatibility with
-            DID tooling, <code>application/did+json</code> (and <code>application/did+ld+json</code>) are
-            equally acceptable.
+            or enhanced). The document is JSON-LD (it includes a <code>@context</code>), and therefore also
+            plain JSON; for interoperability with DID resolution tooling, the endpoint SHOULD serve it with the
+            DID-specific media type <code>application/did+json</code> (or <code>application/did+ld+json</code>).
           </p>
           <p>
             When serving DID documents via HTTP, servers SHOULD include the following headers:


### PR DESCRIPTION
The three small spec edits between here and a CG Draft Report (#100).

- **#127** — HTTP resolution path is now **normative**: the document MUST be at `/.well-known/did/nostr/<pubkey>.json` (lowercase 64-hex, `.json` suffix, `application/did+json`).
- **#128** — minimal resolution specifies **relative** `#key1` refs for `authentication`/`assertionMethod`; verification method `id`/`controller` stay absolute (matches the vectors, Beacon, and the resolver).
- **#126** — reframed operations: **Update** is accurate (binding is permanent; the document is a projection of signed events; `modified` reflects changes), and **Deactivate** honestly states there's no native rotation/revocation yet (open item, tracked in #73).

Closes #126, #127, #128.