### PR TITLE
Publish as a Community Group Draft Report (specStatus CG-DRAFT)

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,16 +33,6 @@
         ],
         shortName: 'did-nostr',
         github: 'https://github.com/nostrcg/did-nostr',
-        logos: [
-          {
-            src: 'https://avatars.githubusercontent.com/u/131810998?s=200&v=4',
-            url: 'https://avatars.githubusercontent.com/u/131810998?s=200&v=4',
-            alt: 'W3C Nostr CG',
-            width: 100,
-            height: 100,
-            id: 'w3c-nostr'
-          }
-        ],
         lint: {
           "no-unused-dfns": false
         },
@@ -68,11 +58,7 @@
     </section>
     <section id="sotd">
       <p>
-        This document is a draft specification produced by the <a href="https://www.w3.org/community/nostr/">W3C Nostr Community Group</a>. 
-        It is not a W3C Standard nor is it on the W3C Standards Track.
-      </p>
-      <p>
-        This specification is intended to provide a stable foundation for implementing Nostr-based Decentralized Identifiers. 
+        This specification is intended to provide a stable foundation for implementing Nostr-based Decentralized Identifiers.
         Feedback and contributions are encouraged through the <a href="https://github.com/nostrcg/did-nostr">GitHub repository</a>.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       const respecConfig = {
         specStatus: 'CG-DRAFT',
         group: 'nostr',
-        subtitle: 'Version 0.0.12',
+        subtitle: 'Version 0.1.0',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',
         editors: [
           {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     ></script>
     <script class="remove">
       const respecConfig = {
-        specStatus: 'unofficial',
+        specStatus: 'CG-DRAFT',
         group: 'nostr',
         subtitle: 'Version 0.0.12',
         latestVersion: 'https://nostrcg.github.io/did-nostr/',


### PR DESCRIPTION
Closes #134. Flips the ReSpec `specStatus` from `'unofficial'` to **`'CG-DRAFT'`**, so the spec renders and publishes as a **W3C Community Group Draft Report** — the **0.1** milestone (#100).

The spec is ready: 0.0.12 + the pre-0.1 batch (#126/#127/#128), normative resolution, conformance vectors, **two published conformant implementations** ([`nostr-beacon`](https://www.npmjs.com/package/nostr-beacon), [`did-nostr`](https://www.npmjs.com/package/did-nostr)) + a DIF Universal Resolver driver, and an existing DID-registry entry.

Draft Reports publish immediately (no FSA/commitment period — that's a *Final* Report concern, gated on #73).