### PR TITLE
Lead @context with did/v1 for DID Core conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When a Nostr DID is resolved, it produces a DID Document like this:
 
 ```json
 {
-  "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
+  "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
   "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
   "type": "DIDNostr",
   "verificationMethod": [
@@ -54,7 +54,7 @@ When a Nostr DID is resolved, it produces a DID Document like this:
 
 ```json
 {
-  "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
+  "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
   "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
   "type": "DIDNostr",
   "verificationMethod": [

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
           <p>The following minimal DID document can be generated from the public key alone, without network access:</p>
           <pre class="example">
 {
-    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -184,7 +184,7 @@
           <p>When enhanced through relay queries, additional service endpoints can be included:</p>
           <pre class="example">
 {
-    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -219,7 +219,7 @@
           <p>A fully enhanced DID document can include profile information and social relationships:</p>
           <pre class="example">
 {
-    "@context": ["https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
+    "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3.org/ns/cid/v1", "https://w3id.org/nostr/context"],
     "id": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
     "alsoKnownAs": [
         "https://alice.example.com/#me",
@@ -277,9 +277,12 @@
           secp256k1 public keys for Data Integrity implementations. This method transforms the x-only 
           BIP-340 public key from the DID identifier into a format compatible with W3C Verifiable 
           Credentials Data Integrity specifications. The <code>Multikey</code> type and the
-          <code>publicKeyMultibase</code> property are defined by Controlled Identifiers v1.0 [[CID]];
-          accordingly, DID documents include <code>https://www.w3.org/ns/cid/v1</code> in their
-          <code>@context</code> so that these terms are well defined under JSON-LD processing.
+          <code>publicKeyMultibase</code> property are defined by Controlled Identifiers v1.0 [[CID]].
+          Accordingly, the <code>@context</code> of a DID document leads with
+          <code>https://www.w3.org/ns/did/v1</code>, as required by [[DID-CORE]], followed by
+          <code>https://www.w3.org/ns/cid/v1</code> so that these terms are well defined under
+          JSON-LD processing. The two contexts define their shared protected terms identically,
+          so they compose without conflict.
         </p>
         
         <p>

--- a/test-vectors/test-vectors-generated.json
+++ b/test-vectors/test-vectors-generated.json
@@ -132,6 +132,7 @@
         "input": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
         "output": {
           "@context": [
+            "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1",
             "https://w3id.org/nostr/context"
           ],
@@ -159,6 +160,7 @@
         "input": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
         "output": {
           "@context": [
+            "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1",
             "https://w3id.org/nostr/context"
           ],
@@ -199,6 +201,7 @@
         "input": "did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2",
         "output": {
           "@context": [
+            "https://www.w3.org/ns/did/v1",
             "https://www.w3.org/ns/cid/v1",
             "https://w3id.org/nostr/context"
           ],


### PR DESCRIPTION
Fixes #136. Tracking: #138.

DID documents now lead their `@context` with `https://www.w3.org/ns/did/v1`, as required by DID Core 1.0, keeping `https://www.w3.org/ns/cid/v1` alongside for the `Multikey` / `publicKeyMultibase` term definitions:

```json
"@context": [
  "https://www.w3.org/ns/did/v1",
  "https://www.w3.org/ns/cid/v1",
  "https://w3id.org/nostr/context"
]
```

Raised by Will Abramson on the [CCG thread](https://lists.w3.org/Archives/Public/public-credentials/2026Jul/0002.html); the fix follows the approach posted back to the list ([0027](https://lists.w3.org/Archives/Public/public-credentials/2026Jul/0027.html)).

## Changes

- `index.html` — three DID document examples, plus the Multikey prose now states that `@context` leads with `did/v1` per DID Core, followed by `cid/v1`
- `README.md` — both examples
- `test-vectors/test-vectors-generated.json` — the three `did_document_generation` vectors (hand-edited pending generator update, cc @amir-hameed-mir)

## Verification

- `did/v1` and `cid/v1` define all 11 shared `@protected` terms identically (`cid/v1` is byte-identical to `did/v1.1rc1`), so the contexts compose without protected-term redefinition errors
- All three updated vector documents expand cleanly with jsonld.js against the deployed context files; expanded RDF is unchanged from the previous `cid/v1`-first form, so this is semantically a no-op

## Not in this PR

- `nostr-beacon` and the `did-nostr` resolver (`src/diddoc.js` in each) need the matching change — separate PRs
- Version bump to 0.1.1 left for the release batch
- Future swap of `did/v1` → `did/v1.1` once published at the canonical URL (tracked in #138)