### PR TITLE
Fix invalid npub in the npub-relationship example mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           <ul>
             <li>Raw public key: <code>124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
             <li>DID: <code>did:nostr:124c0fa99407182ece5a24fad9b7f6674902fc422843d3128d38a0afbee0fdd2</code></li>
-            <li>Display npub: <code>npub1cpxejnc58zpcuyh0pt8gvkzpv34qxceu0sqp7jec2nk9nut7p5zs4zyx4c</code></li>
+            <li>Display npub: <code>npub1zfxql2v5quvzanj6ynadndlkvays9lzz9ppaxy5d8zs2l0hqlhfq8fdyst</code></li>
           </ul>
         </p>
       </section>


### PR DESCRIPTION
The example npub in the "Relationship with Nostr npubs" section failed bech32 checksum verification — it was not the encoding of the example key (or any key), and any NIP-19 decoder rejects it.

This replaces it with the valid NIP-19 encoding of `124c0fa9…fdd2`:

```
npub1zfxql2v5quvzanj6ynadndlkvays9lzz9ppaxy5d8zs2l0hqlhfq8fdyst
```

verified with a bech32 implementation checked against the NIP-19 reference vector. This keeps the example mapping (on-topic for this section, which explicitly permits UIs to display npub alongside the DID) — see #141 for the alternative of dropping the display bullet entirely.

The Primer (#140) inherited the same string and has already been updated there to show only hex forms.

Fixes #141